### PR TITLE
fix error: invalid cast from type

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Control external WLED from ESPHome.
 external_components:
   - source:
       type: git
-      url: https://github.com/muxa/esphome-wled-output
+      url: https://github.com/fabio-garavini/esphome-wled-output
 
 ```
 

--- a/components/wled_output/light/wled_light_output.h
+++ b/components/wled_output/light/wled_light_output.h
@@ -59,7 +59,7 @@ class WLEDLightOutput : public light::AddressableLight {
 
   inline int32_t size() const override { return num_leds_; }
 
-  void set_address(network::IPAddress address) { this->address_ = IPAddress((uint32_t)address); }
+  void set_address(network::IPAddress address) { this->address_ = address; }
   void set_port(uint16_t port) { this->port_ = port; }
 
 


### PR DESCRIPTION
fix error: invalid cast from type 'esphome::network::IPAddress' to type 'uint32_t' {aka 'unsigned int'}